### PR TITLE
Improve setup instructions and fix unauthorized voting security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The password necessary to access VS Code will be printed in the console.
 ### Local setup
 
 - Install Zokrates by running `curl -LSfs get.zokrat.es | sh` and adding `~/.zokrates/bin` to your `PATH` variable.
+- (Linux: Run `apt install libgmp3-dev`)
 - Run `pip install -r ./requirements.txt`
 
 ## Running the server
@@ -58,6 +59,11 @@ $ openssl genrsa -out private_key.pem 1024
 ```
 
 This will generate a `private_key.pem` in your working directory, which should be kept secret.
+
+Extract the public key by running:
+```
+openssl rsa -in private_key.pem -outform PEM -pubout -out key.pub
+```
 To whitelist the public key, copy `key.pub` into `accepted_public_keys`.
 
 To vote, run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+wheel
 Flask
 typer
 markupsafe==2.0.1
-click==7.1.1
 ecdsa
 fastecdsa
 sympy

--- a/src/voting_server.py
+++ b/src/voting_server.py
@@ -32,13 +32,13 @@ def vote():
     commitment = bytes.fromhex(data["commitment"])
     public_key_str = data["public_key"]
     signature = bytes.fromhex(data["signature"])
-    
-    assert (
-        public_key_str in PUBLIC_KEY_WHITELIST,
+
+    assert public_key_str in PUBLIC_KEY_WHITELIST, (
         "Public key not in whitelist!\n"
         + f"Public key: {public_key_str}\n"
         + f"White list: {PUBLIC_KEY_WHITELIST}"
     )
+
     if "DEBUG_ALLOW_DOUBLE_VOTING" not in os.environ:
         assert public_key_str not in keys_with_commitments, "Public key already voted!"
 
@@ -52,7 +52,6 @@ def vote():
     keys_with_commitments.append(public_key_str)
 
     return "OK"
-
 
 
 @app.route("/reveal_vote", methods=["POST"])

--- a/src/voting_server.py
+++ b/src/voting_server.py
@@ -13,7 +13,7 @@ from pathlib import Path
 PUBLIC_KEY_WHITELIST = []
 for public_key_path in Path("../accepted_public_keys").glob("*.pub"):
     with public_key_path.open() as f:
-        PUBLIC_KEY_WHITELIST.append(f.read())
+        PUBLIC_KEY_WHITELIST.append(f.read().strip())
 
 # Flask server is started from <project dir> / src
 PROVER = ZokratesProver(Path(".."))


### PR DESCRIPTION
The assertion was always true, because the parentheses were set incorrectly, asserting a tuple instead of the condition.